### PR TITLE
Fix Fan state logic for core 300s devices

### DIFF
--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -26,7 +26,7 @@ void LevoitFan::setup() {
     [this](uint32_t currentBits) {
       bool powerState = (currentBits & powerMask) == powerMask;
 
-      this->state = currentBits & powerState;
+      this->state = currentBits && powerState;
 
       ESP_LOGI(TAG, "powerState: %d, currentBits: %d, powerMask: %d, state: %d", powerState, currentBits, powerMask, this->state);
       uint8_t newSpeed;

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -59,27 +59,14 @@ void LevoitFan::control(const fan::FanCall &call) {
   if (call.get_state().has_value()) {
     newPowerState = *call.get_state();
     
-    switch (this->parent_->device_model_) {
-      case LevoitDeviceModel::CORE_400S:
-      case LevoitDeviceModel::CORE_300S:
-      case LevoitDeviceModel::CORE_200S:
-        if (newPowerState) {
-          onMask |= static_cast<uint32_t>(LevoitState::POWER) + static_cast<uint32_t>(LevoitState::FAN_MANUAL);
-          offMask &= ~static_cast<uint32_t>(LevoitState::POWER);
-        } else {
-          onMask &= ~static_cast<uint32_t>(LevoitState::POWER);
-          offMask |= static_cast<uint32_t>(LevoitState::POWER);
-        }
-        break;
-      default:
-        if (newPowerState) {
-          onMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL);
-          offMask &= ~static_cast<uint32_t>(LevoitState::FAN_MANUAL);
-        } else {
-          onMask &= ~static_cast<uint32_t>(LevoitState::FAN_MANUAL);
-          offMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL);
-        }
+    if (newPowerState) {
+      onMask |= static_cast<uint32_t>(LevoitState::POWER) + static_cast<uint32_t>(LevoitState::FAN_MANUAL);
+      offMask &= ~static_cast<uint32_t>(LevoitState::POWER);
+    } else {
+      onMask &= ~static_cast<uint32_t>(LevoitState::POWER);
+      offMask |= static_cast<uint32_t>(LevoitState::POWER);
     }
+
   }
 
   if (call.get_speed().has_value()) {

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -28,6 +28,7 @@ void LevoitFan::setup() {
 
       this->state = currentBits & powerState;
 
+      ESP_LOGI(TAG, "powerState: %d, currentBits: %d, powerMask: %d, state: %d", powerState, currentBits, powerMask, this->state);
       uint8_t newSpeed;
 
       if (currentBits & static_cast<uint32_t>(LevoitState::FAN_SPEED1))

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -17,7 +17,7 @@ void LevoitFan::setup() {
       break;
     default:
       //represensts fan mode
-      powerMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL);
+      powerMask |= (static_cast<uint32_t>(LevoitState::POWER) + static_cast<uint32_t>(LevoitState::FAN_MANUAL));
   }
 
   listenMask |= powerMask;
@@ -28,7 +28,7 @@ void LevoitFan::setup() {
 
       this->state = currentBits && powerState;
 
-      ESP_LOGI(TAG, "powerState: %d, currentBits: %d, powerMask: %d, state: %d", powerState, currentBits, powerMask, this->state);
+      ESP_LOGI(TAG, "a powerState: %d, currentBits: %d, powerMask: %d, state: %d", powerState, currentBits, powerMask, this->state);
       uint8_t newSpeed;
 
       if (currentBits & static_cast<uint32_t>(LevoitState::FAN_SPEED1))

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -9,16 +9,7 @@ static const char *const TAG = "levoit.fan";
 void LevoitFan::setup() {
   uint32_t listenMask = this->parent_->fanChangeMask;
 
-  switch (this->parent_->device_model_) {
-    // represents power mode
-    case LevoitDeviceModel::CORE_400S:
-    case LevoitDeviceModel::CORE_200S:
-      powerMask |= (static_cast<uint32_t>(LevoitState::POWER) + static_cast<uint32_t>(LevoitState::FAN_MANUAL));
-      break;
-    default:
-      //represensts fan mode
-      powerMask |= (static_cast<uint32_t>(LevoitState::POWER) + static_cast<uint32_t>(LevoitState::FAN_MANUAL));
-  }
+  powerMask |= (static_cast<uint32_t>(LevoitState::POWER) + static_cast<uint32_t>(LevoitState::FAN_MANUAL));
 
   listenMask |= powerMask;
 
@@ -26,9 +17,8 @@ void LevoitFan::setup() {
     [this](uint32_t currentBits) {
       bool powerState = (currentBits & powerMask) == powerMask;
 
-      this->state = currentBits && powerState;
+      this->state = powerState;
 
-      ESP_LOGI(TAG, "a powerState: %d, currentBits: %d, powerMask: %d, state: %d", powerState, currentBits, powerMask, this->state);
       uint8_t newSpeed;
 
       if (currentBits & static_cast<uint32_t>(LevoitState::FAN_SPEED1))

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -61,6 +61,7 @@ void LevoitFan::control(const fan::FanCall &call) {
     
     switch (this->parent_->device_model_) {
       case LevoitDeviceModel::CORE_400S:
+      case LevoitDeviceModel::CORE_300S:
       case LevoitDeviceModel::CORE_200S:
         if (newPowerState) {
           onMask |= static_cast<uint32_t>(LevoitState::POWER) + static_cast<uint32_t>(LevoitState::FAN_MANUAL);


### PR DESCRIPTION
closes #22 

After doing some analysis I've found that the differentiation the fan state logic made between the 300 and 200/400 devices is not needed. My 300s works with the logic of the 200/400 devices. Therefore I have removed the differentiation between the devices for state reporting.

Furthermore I've simplified the state evaluation logic. The bitwise comparison between the currentbits and the powerstate will always report the result as powerstate, since the currentbits are already used to calculate powerstate