### PR TITLE
Fix PM2.5 values always reporting as 0

### DIFF
--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -444,7 +444,7 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
       pm25NAN = (payload[12] == 0xFF && payload[13] == 0xFF);
       if (!pm25NAN) {
         uint16_t raw_value = (payload[13] << 8) + payload[12];
-        uint32_t new_pm25Value = (raw_value * 10) / 10000;
+        uint32_t new_pm25Value = (raw_value * 10);
         
         if (new_pm25Value != pm25_value) {
           pm25Change = true;

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -444,13 +444,12 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
       pm25NAN = (payload[12] == 0xFF && payload[13] == 0xFF);
       if (!pm25NAN) {
         uint16_t raw_value = (payload[13] << 8) + payload[12];
-        
+        uint32_t new_pm25Value = 0;
         switch (this->device_model_) {
           case LevoitDeviceModel::CORE_200S:
-            new_pm25Value = raw_value / 10000;
+            new_pm25Value = raw_value / 1000;
             break;
 
-          case LevoitDeviceModel::UNKNOWN:
           case LevoitDeviceModel::CORE_300S:
           case LevoitDeviceModel::CORE_400S:
           default:

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -444,7 +444,7 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
       pm25NAN = (payload[12] == 0xFF && payload[13] == 0xFF);
       if (!pm25NAN) {
         uint16_t raw_value = (payload[13] << 8) + payload[12];
-        uint32_t new_pm25Value = new_pm25Value = raw_value * 10;
+        uint32_t new_pm25Value = (raw_value * 10);
         
         if (new_pm25Value != pm25_value) {
           pm25Change = true;

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -444,7 +444,19 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
       pm25NAN = (payload[12] == 0xFF && payload[13] == 0xFF);
       if (!pm25NAN) {
         uint16_t raw_value = (payload[13] << 8) + payload[12];
-        uint32_t new_pm25Value = (raw_value * 10);
+        
+        switch (this->device_model_) {
+          case LevoitDeviceModel::CORE_200S:
+          pm25_value = raw_value / 10000;
+          break;
+
+          case LevoitDeviceModel::UNKNOWN:
+          case LevoitDeviceModel::CORE_300S:
+          case LevoitDeviceModel::CORE_400S:
+          default:
+            pm25_value = raw_value * 10;
+            break;
+        }
         
         if (new_pm25Value != pm25_value) {
           pm25Change = true;

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -444,18 +444,7 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
       pm25NAN = (payload[12] == 0xFF && payload[13] == 0xFF);
       if (!pm25NAN) {
         uint16_t raw_value = (payload[13] << 8) + payload[12];
-        uint32_t new_pm25Value = 0;
-        switch (this->device_model_) {
-          case LevoitDeviceModel::CORE_200S:
-            new_pm25Value = raw_value / 1000;
-            break;
-
-          case LevoitDeviceModel::CORE_300S:
-          case LevoitDeviceModel::CORE_400S:
-          default:
-              new_pm25Value = raw_value * 10;
-              break;
-        }
+        uint32_t new_pm25Value = new_pm25Value = raw_value * 10;
         
         if (new_pm25Value != pm25_value) {
           pm25Change = true;

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -447,15 +447,15 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
         
         switch (this->device_model_) {
           case LevoitDeviceModel::CORE_200S:
-          pm25_value = raw_value / 10000;
-          break;
+            new_pm25Value = raw_value / 10000;
+            break;
 
           case LevoitDeviceModel::UNKNOWN:
           case LevoitDeviceModel::CORE_300S:
           case LevoitDeviceModel::CORE_400S:
           default:
-            pm25_value = raw_value * 10;
-            break;
+              new_pm25Value = raw_value * 10;
+              break;
         }
         
         if (new_pm25Value != pm25_value) {


### PR DESCRIPTION
This patch corrects the PM2.5 value scaling logic for 300S/400S

Previously, the raw PM2.5 value was scaled using `(value * 10) / 10000`, which caused almost all real-world readings to truncate to zero due to integer division. As a result, Home Assistant always displayed 0.0 for PM2.5.

This fix removes the unnecessary division and scales the raw value with `(value * 10)` to align with the expected internal format used by the existing PM2.5 sensor logic.

The resulting values now match the 400S display and report correctly in Home Assistant. This was also tested and verified working with the 300S

Closes #9 
Partially addresses #18 
