### PR TITLE
fix: status_poll_seconds is calling set_command_timeout

### DIFF
--- a/components/levoit/__init__.py
+++ b/components/levoit/__init__.py
@@ -40,4 +40,4 @@ async def to_code(config):
     if CONF_COMMAND_TIMEOUT in config:
         cg.add(var.set_command_timeout(config[CONF_COMMAND_TIMEOUT]))
     if CONF_STATUS_POLL_SECONDS in config:
-        cg.add(var.set_command_timeout(config[CONF_STATUS_POLL_SECONDS]))
+        cg.add(var.set_status_poll_seconds(config[CONF_STATUS_POLL_SECONDS]))


### PR DESCRIPTION
Seems like copy-cat got a bit too ambitious and copied the wrong function call. :cat: 