### PR TITLE
The sensor section needs to be uncommented for the PM2.5 and air_quality sensors to work.

### DIFF
--- a/sample-levoit-300s-configuration.yaml
+++ b/sample-levoit-300s-configuration.yaml
@@ -52,7 +52,7 @@ fan:
   - platform: levoit
     name: Levoit Purifier
 
-#sensor:
+sensor:
 #   Uptime sensor.
 #  - platform: uptime
 #    name: Uptime


### PR DESCRIPTION
The sensor section needs to be uncommented for the PM2.5 and air_quality sensors to work.