### PR TITLE
Connect GPIO to ground for bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ For details on the teardown please read the [blog post](https://vigue.me/posts/l
 ## Flash
 - Copy the provided sample configuration for your model to a new ESPHome configuration, while keeping the generated passwords
 - Compile and download the binary (Choose the modern format once compilation has completed)
-- Solder wires to pins TXD0, RXD0, +3V3, and GND near the ESP32 on the logic board, and connect these to a USB-UART converter
+- Solder wires to pins TXD0, RXD0, IO0, +3V3, and GND near the ESP32 on the logic board, and connect these to a USB-UART converter
+- Connect IO0 to ground during power before connecting USB-UART to boot to bootloader.
 
 ### Backup Existing Firmware
 ```bash


### PR DESCRIPTION
After following steps. Realized that GPIO0 needs to be pulled low to enable bootloader mode.

https://www.espressif.com/sites/default/files/documentation/esp32-solo-1_datasheet_en.pdf