### PR TITLE
Updates for fan modes and light entities

### DIFF
--- a/components/levoit/button/__init__.py
+++ b/components/levoit/button/__init__.py
@@ -1,7 +1,7 @@
 from esphome.components import button
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import ICON_RESTART
+from esphome.const import ICON_RESTART, ENTITY_CATEGORY_CONFIG
 from .. import levoit_ns, CONF_LEVOIT_ID, Levoit
 
 DEPENDENCIES = ["levoit"]
@@ -15,7 +15,7 @@ CONF_FILTER_RESET = "filter_reset"
 CONFIG_SCHEMA = (
     cv.Schema({
         cv.GenerateID(CONF_LEVOIT_ID): cv.use_id(Levoit),
-        cv.Optional(CONF_FILTER_RESET): button.button_schema(LevoitButton, icon=ICON_RESTART).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_FILTER_RESET): button.button_schema(LevoitButton, entity_category=ENTITY_CATEGORY_CONFIG, icon=ICON_RESTART).extend(cv.COMPONENT_SCHEMA),
     })
 )
 

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -56,13 +56,18 @@ void LevoitFan::setup() {
   // Construct traits
   switch (this->parent_->device_model_) {
     case LevoitDeviceModel::CORE_400S:
-      // 400s has 4 speeds
       this->traits_ = fan::FanTraits(false, true, false, 4);
-      this->traits_.set_supported_preset_modes({"Manual", "Sleep", "Auto"});  // TODO: 300s also has auto
+      this->traits_.set_supported_preset_modes({"Manual", "Sleep", "Auto"});
+      break;
+    case LevoitDeviceModel::CORE_300S:
+      this->traits_ = fan::FanTraits(false, true, false, 4);
+      this->traits_.set_supported_preset_modes({"Manual", "Sleep", "Auto"});
+      break;
+    case LevoitDeviceModel::CORE_200S:
     default:
-      // 200s, 300s has 3 speeds
       this->traits_ = fan::FanTraits(false, true, false, 3);
       this->traits_.set_supported_preset_modes({"Manual", "Sleep"});
+      break;
   }
 }
 

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -20,7 +20,7 @@ void LevoitFan::setup() {
 
       if (!this->state || currentBits & static_cast<uint32_t>(LevoitState::FAN_MANUAL))
       {
-        this->preset_mode = "Manual";
+        this->set_preset_mode_("Manual");
         uint8_t newSpeed = 0;
 
         if (currentBits & static_cast<uint32_t>(LevoitState::FAN_SPEED1))
@@ -36,12 +36,12 @@ void LevoitFan::setup() {
       }
       else if (currentBits & static_cast<uint32_t>(LevoitState::FAN_AUTO))
       {
-        this->preset_mode = "Auto";
+        this->set_preset_mode_("Auto");
         this->speed = 0;
       }
       else if (currentBits & static_cast<uint32_t>(LevoitState::FAN_SLEEP))
       {
-        this->preset_mode = "Sleep";
+        this->set_preset_mode_("Sleep");
         this->speed = 0;
       }
       else
@@ -122,17 +122,19 @@ void LevoitFan::control(const fan::FanCall &call) {
     }
   }
 
-  std::string mode = call.get_preset_mode();
-  ESP_LOGV(TAG, "Setting fan mode = %s", mode.c_str());
-  if (mode == "Manual") {
-    onMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL) + static_cast<uint32_t>(LevoitState::POWER);
-    offMask |= static_cast<uint32_t>(LevoitState::FAN_AUTO) + static_cast<uint32_t>(LevoitState::FAN_SLEEP);
-  } else if (mode == "Auto") {
-    onMask |= static_cast<uint32_t>(LevoitState::FAN_AUTO) + static_cast<uint32_t>(LevoitState::POWER);
-    offMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL) + static_cast<uint32_t>(LevoitState::FAN_SLEEP);
-  } else if (mode == "Sleep") {
-    onMask |= static_cast<uint32_t>(LevoitState::FAN_SLEEP) + static_cast<uint32_t>(LevoitState::POWER);
-    offMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL) + static_cast<uint32_t>(LevoitState::FAN_AUTO);
+  if (call.has_preset_mode()) {
+    std::string mode = call.get_preset_mode();
+    ESP_LOGV(TAG, "Setting fan mode = %s", mode.c_str());
+    if (mode == "Manual") {
+      onMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL) + static_cast<uint32_t>(LevoitState::POWER);
+      offMask |= static_cast<uint32_t>(LevoitState::FAN_AUTO) + static_cast<uint32_t>(LevoitState::FAN_SLEEP);
+    } else if (mode == "Auto") {
+      onMask |= static_cast<uint32_t>(LevoitState::FAN_AUTO) + static_cast<uint32_t>(LevoitState::POWER);
+      offMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL) + static_cast<uint32_t>(LevoitState::FAN_SLEEP);
+    } else if (mode == "Sleep") {
+      onMask |= static_cast<uint32_t>(LevoitState::FAN_SLEEP) + static_cast<uint32_t>(LevoitState::POWER);
+      offMask |= static_cast<uint32_t>(LevoitState::FAN_MANUAL) + static_cast<uint32_t>(LevoitState::FAN_AUTO);
+    }
   }
 
   if (onMask || offMask) {

--- a/components/levoit/fan/levoit_fan.h
+++ b/components/levoit/fan/levoit_fan.h
@@ -13,11 +13,12 @@ class LevoitFan : public Component, public fan::Fan {
   void setup() override;
   void dump_config() override;
 
-  fan::FanTraits get_traits() override;
+  fan::FanTraits get_traits() override { return this->traits_; }
 
  protected:
   void control(const fan::FanCall &call) override;
   Levoit *parent_;
+  fan::FanTraits traits_;
 
  private:
   uint32_t powerMask = 0;

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -293,7 +293,7 @@ void Levoit::command_sync_() {
         .payload_len = 2
       });
       // setting that its done, not sure how to check filter status yet
-      current_state_ &= ~static_cast<uint32_t>(LevoitState::FILTER_RESET);
+      req_on_state_ &= ~static_cast<uint32_t>(LevoitState::FILTER_RESET);
     }
 
     if (req_off_state_ & static_cast<uint32_t>(LevoitState::AIR_QUALITY_CHANGE))

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -50,7 +50,7 @@ void Levoit::setup() {
 }
 
 void Levoit::maint_task_() {
-  uint32_t lastStatusPollTime = xTaskGetTickCount();
+  uint32_t lastStatusPollTime = 0;
 
   while (true) {
     // wait with timeout for notification
@@ -126,7 +126,8 @@ void Levoit::maint_task_() {
 
       xSemaphoreGive(stateChangeMutex_);
     }
-    if (this->status_poll_seconds > 0 && (xTaskGetTickCount() - lastStatusPollTime) >= pdMS_TO_TICKS(this->status_poll_seconds * 1000)) {
+    if ( lastStatusPollTime == 0 ||
+       (this->status_poll_seconds > 0 && (xTaskGetTickCount() - lastStatusPollTime) >= pdMS_TO_TICKS(this->status_poll_seconds * 1000))) {
       send_command_(LevoitCommand {
         .payloadType = LevoitPayloadType::STATUS_REQUEST,
         .packetType = LevoitPacketType::SEND_MESSAGE,

--- a/components/levoit/levoit.h
+++ b/components/levoit/levoit.h
@@ -110,8 +110,7 @@ class Levoit : public Component, public uart::UARTDevice {
     static_cast<uint32_t>(LevoitState::FAN_SPEED1) |
     static_cast<uint32_t>(LevoitState::FAN_SPEED2) |
     static_cast<uint32_t>(LevoitState::FAN_SPEED3) |
-    static_cast<uint32_t>(LevoitState::FAN_SPEED4) |
-    static_cast<uint32_t>(LevoitState::FAN_SLEEP);
+    static_cast<uint32_t>(LevoitState::FAN_SPEED4);
   uint32_t pm25_value = 1000;
   uint8_t air_quality = 255;
 

--- a/components/levoit/light/__init__.py
+++ b/components/levoit/light/__init__.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import light
+
+from .. import levoit_ns, CONF_LEVOIT_ID, Levoit
+
+DEPENDENCIES = ["levoit"]
+CODEOWNERS = ["@acvigue"]
+
+LevoitLight = levoit_ns.class_("LevoitLight", cg.Component, light.LightOutput)
+
+CONFIG_SCHEMA = light.light_schema(
+    LevoitLight, light.LightType.BINARY
+).extend(
+    {
+        cv.GenerateID(CONF_LEVOIT_ID): cv.use_id(Levoit),
+    }
+)
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_LEVOIT_ID])
+    var = await light.new_light(config, parent)
+    await cg.register_component(var, config)

--- a/components/levoit/light/levoit_light.cpp
+++ b/components/levoit/light/levoit_light.cpp
@@ -1,0 +1,69 @@
+#include "esphome/core/log.h"
+#include "levoit_light.h"
+
+namespace esphome {
+namespace levoit {
+
+static const char *const TAG = "levoit.light";
+
+void LevoitLight::setup_state(light::LightState *state) {
+  this->state_ = state;
+}
+
+void LevoitLight::setup() {
+  this->parent_->register_state_listener(
+    static_cast<uint32_t>(LevoitState::NIGHTLIGHT_OFF) +
+    static_cast<uint32_t>(LevoitState::NIGHTLIGHT_LOW) +
+    static_cast<uint32_t>(LevoitState::NIGHTLIGHT_HIGH),
+    [this](uint32_t currentBits) {
+      this->publish_state(currentBits);
+    }
+  );
+}
+
+void LevoitLight::publish_state(uint32_t currentBits) {
+  this->write_ = false;
+  if (currentBits & static_cast<uint32_t>(LevoitState::NIGHTLIGHT_HIGH))
+    this->state_->turn_on().set_brightness(1.0).perform();
+  else if (currentBits & static_cast<uint32_t>(LevoitState::NIGHTLIGHT_LOW))
+    this->state_->turn_on().set_brightness(0.5).perform();
+  else
+    this->state_->turn_off().perform();
+}
+
+void LevoitLight::write_state(light::LightState *state) {
+  if (!this->write_) {
+    this->write_ = true;
+    return;
+  }
+  float brightness;
+  state->current_values_as_brightness(&brightness);
+
+  std::string level;
+  uint32_t onMask = 0;
+  uint32_t offMask = 0;
+
+  if (brightness == 0.0) {
+    level = "OFF";
+    onMask |= static_cast<uint32_t>(LevoitState::NIGHTLIGHT_OFF);
+    offMask |= static_cast<uint32_t>(LevoitState::NIGHTLIGHT_LOW) + static_cast<uint32_t>(LevoitState::NIGHTLIGHT_HIGH);
+  }
+  else if (brightness < 0.505) {
+    level = "LOW";
+    onMask |= static_cast<uint32_t>(LevoitState::NIGHTLIGHT_LOW);
+    offMask |= static_cast<uint32_t>(LevoitState::NIGHTLIGHT_OFF) + static_cast<uint32_t>(LevoitState::NIGHTLIGHT_HIGH);
+    this->publish_state(static_cast<uint32_t>(LevoitState::NIGHTLIGHT_LOW));
+  }
+  else {
+    level = "HIGH";
+    onMask |= static_cast<uint32_t>(LevoitState::NIGHTLIGHT_HIGH);
+    offMask |= static_cast<uint32_t>(LevoitState::NIGHTLIGHT_OFF) + static_cast<uint32_t>(LevoitState::NIGHTLIGHT_LOW);
+    this->publish_state(static_cast<uint32_t>(LevoitState::NIGHTLIGHT_HIGH));
+  }
+  ESP_LOGD(TAG, "'%s': Setting state %0.6f -> %s", state->get_name().c_str(), brightness, level.c_str());
+  this->parent_->set_request_state(onMask, offMask);
+  return;
+}
+
+}  // namespace levoit
+}  // namespace esphome

--- a/components/levoit/light/levoit_light.h
+++ b/components/levoit/light/levoit_light.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/levoit/levoit.h"
+#include "esphome/components/light/light_output.h"
+
+#include <vector>
+
+namespace esphome {
+namespace levoit {
+
+class LevoitLight : public light::LightOutput, public Component {
+ public:
+  LevoitLight(Levoit *parent) : parent_(parent) {};
+  void setup() override;
+
+  light::LightTraits get_traits() override {
+    auto traits = light::LightTraits();
+    traits.set_supported_color_modes({light::ColorMode::BRIGHTNESS});
+    return traits;
+  }
+
+  void setup_state(light::LightState *state) override;
+  void write_state(light::LightState *state) override;
+
+ protected:
+  light::LightState *state_;
+  Levoit *parent_;
+  bool write_ = false;
+
+  void publish_state(uint32_t currentBits);
+};
+
+}  // namespace levoit
+}  // namespace esphome

--- a/components/levoit/sensor/__init__.py
+++ b/components/levoit/sensor/__init__.py
@@ -33,10 +33,10 @@ CONFIG_SCHEMA = (
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_LEVOIT_ID])
 
-    if pm25 := config.get(CONF_PM_2_5):
-        var = await sensor.new_sensor(pm25, parent, LevoitSensorPurpose.PM25)
-        await cg.register_component(var, pm25)
+    if config_pm25 := config.get(CONF_PM_2_5):
+        var = await sensor.new_sensor(config_pm25, parent, LevoitSensorPurpose.PM25)
+        await cg.register_component(var, config_pm25)
 
-    if air_quality := config.get(CONF_AIR_QUALITY):
-        var = await sensor.new_sensor(air_quality, parent, LevoitSensorPurpose.AIR_QUALITY)
-        await cg.register_component(var, air_quality)
+    if config_air_quality := config.get(CONF_AIR_QUALITY):
+        var = await sensor.new_sensor(config_air_quality, parent, LevoitSensorPurpose.AIR_QUALITY)
+        await cg.register_component(var, config_air_quality)

--- a/components/levoit/switch/__init__.py
+++ b/components/levoit/switch/__init__.py
@@ -1,7 +1,7 @@
 from esphome.components import switch
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import ICON_SECURITY, DEVICE_CLASS_LOCK, CONF_POWER, ICON_POWER, ICON_BRIGHTNESS_5
+from esphome.const import ICON_SECURITY, ENTITY_CATEGORY_CONFIG, CONF_POWER, ICON_POWER, ICON_BRIGHTNESS_5
 from .. import levoit_ns, CONF_LEVOIT_ID, Levoit
 
 DEPENDENCIES = ["levoit"]
@@ -16,8 +16,8 @@ LevoitSwitchPurpose = levoit_ns.enum("LevoitSwitchPurpose")
 CONFIG_SCHEMA = (
     cv.Schema({
         cv.GenerateID(CONF_LEVOIT_ID): cv.use_id(Levoit),
-        cv.Optional(CONF_DISPLAY_LOCK): switch.switch_schema(LevoitSwitch, icon=ICON_SECURITY).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DISPLAY_ON): switch.switch_schema(LevoitSwitch, icon=ICON_BRIGHTNESS_5).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_DISPLAY_LOCK): switch.switch_schema(LevoitSwitch, entity_category=ENTITY_CATEGORY_CONFIG, icon=ICON_SECURITY).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_DISPLAY_ON): switch.switch_schema(LevoitSwitch, entity_category=ENTITY_CATEGORY_CONFIG, icon=ICON_BRIGHTNESS_5).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_POWER): switch.switch_schema(LevoitSwitch, icon=ICON_POWER).extend(cv.COMPONENT_SCHEMA),
     })
 )


### PR DESCRIPTION
- Added support for native fan mode configuration: Manual, Sleep, and Auto (if supported)
- Added new light entity for night light configuration (Core 200s)

Minor changes
- Fixed filter reset command so that it is only sent once
- Request status on startup regardless of `status_poll_seconds` setting
- Updated `filter_reset`, `display_on`, and `display_lock` to be config entities

I was able to test these changes on the Core 200s and 400s.