### PR TITLE
Add support for Core 600S air purifier

### DIFF
--- a/components/levoit/__init__.py
+++ b/components/levoit/__init__.py
@@ -15,7 +15,7 @@ CONF_COMMAND_DELAY = "command_delay"
 CONF_COMMAND_TIMEOUT = "command_timeout"
 CONF_STATUS_POLL_SECONDS = "status_poll_seconds"
 
-VALID_MODELS = ["core200s", "core300s", "core400s"]
+VALID_MODELS = ["core200s", "core300s", "core400s", "core600s"]
 
 levoit_ns = cg.esphome_ns.namespace("levoit")
 Levoit = levoit_ns.class_("Levoit", cg.Component, uart.UARTDevice)

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -55,6 +55,7 @@ void LevoitFan::setup() {
 
   // Construct traits
   switch (this->parent_->device_model_) {
+    case LevoitDeviceModel::CORE_600S:
     case LevoitDeviceModel::CORE_400S:
       this->traits_ = fan::FanTraits(false, true, false, 4);
       this->traits_.set_supported_preset_modes({"Manual", "Sleep", "Auto"});

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -438,11 +438,15 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
       uint8_t displayIndex = 7;
       uint8_t displayLockIndex = 14;
       uint8_t fanSpeedIndex = 9;
+      uint8_t pm25HighIndex = 13;
+      uint8_t pm25LowIndex = 12;
       switch (device_model_) {
         case LevoitDeviceModel::CORE_600S: 
           fanSpeedIndex = 7;
           displayIndex = 9;
           displayLockIndex = 15;
+          pm25HighIndex = 14;
+          pm25LowIndex = 13;
           break;
         case LevoitDeviceModel::CORE_400S:
           fanSpeedIndex = 7;
@@ -483,9 +487,9 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
         nightLightHigh = payload[12] == 0x64;
       } else {
         // Core 300S/400S/600S have PM2.5 sensor at payload[12-13]
-        pm25NAN = (payload[12] == 0xFF && payload[13] == 0xFF);
+        pm25NAN = (payload[pm25LowIndex] == 0xFF && payload[pm25HighIndex] == 0xFF);
         if (!pm25NAN) {
-          uint16_t raw_value = (payload[13] << 8) + payload[12];
+          uint16_t raw_value = (payload[pm25HighIndex] << 8) + payload[pm25LowIndex];
           uint32_t new_pm25Value = (raw_value * 10);
 
           if (new_pm25Value != pm25_value) {

--- a/components/levoit/levoit.h
+++ b/components/levoit/levoit.h
@@ -12,12 +12,12 @@
 namespace esphome {
 namespace levoit {
 
-enum class LevoitDeviceModel : uint8_t { NONE, CORE_200S, CORE_300S, CORE_400S };
+enum class LevoitDeviceModel : uint8_t { NONE, CORE_200S, CORE_300S, CORE_400S, CORE_600S };
 enum class LevoitPacketType : uint8_t { SEND_MESSAGE = 0x22, ACK_MESSAGE = 0x12, ERROR = 0x52 };
 enum class LevoitPayloadType : uint32_t {
   STATUS_REQUEST = 0x013140,
   STATUS_RESPONSE = 0x013040,
-  AUTO_STATUS = 0x016040, // I only know this value for 200S, so might be wrong
+  AUTO_STATUS = 0x016040,  // I only know this value for 200S, so might be wrong
   SET_FAN_AUTO_MODE = 0x01E6A5,
   SET_FAN_MANUAL = 0x0160A2,
   SET_FAN_MODE = 0x01E0A5,
@@ -79,14 +79,21 @@ static_assert(std::is_trivially_copyable<LevoitCommand>::value,
 using PayloadTypeOverrideMap = std::unordered_map<LevoitDeviceModel, std::unordered_map<LevoitPayloadType, uint32_t>>;
 
 static const PayloadTypeOverrideMap MODEL_SPECIFIC_PAYLOAD_TYPES = {
-    {LevoitDeviceModel::CORE_400S,
+    {LevoitDeviceModel::CORE_600S,
      {
-         {LevoitPayloadType::STATUS_REQUEST, 0x01b140}, {LevoitPayloadType::STATUS_RESPONSE, 0x01b040},
+         {LevoitPayloadType::AUTO_STATUS, 0x014041}
          // ... add other model-specific overrides here ...
      }},
-     {LevoitDeviceModel::CORE_200S,
+    {LevoitDeviceModel::CORE_400S,
      {
-         {LevoitPayloadType::STATUS_REQUEST, 0x016140}, {LevoitPayloadType::STATUS_RESPONSE, 0x016140},
+         {LevoitPayloadType::STATUS_REQUEST, 0x01b140},
+         {LevoitPayloadType::STATUS_RESPONSE, 0x01b040},
+         // ... add other model-specific overrides here ...
+     }},
+    {LevoitDeviceModel::CORE_200S,
+     {
+         {LevoitPayloadType::STATUS_REQUEST, 0x016140},
+         {LevoitPayloadType::STATUS_RESPONSE, 0x016140},
          {LevoitPayloadType::AUTO_STATUS, 0x016040}
          // ... add other model-specific overrides here ...
      }},


### PR DESCRIPTION
This PR adds support for the Core 600S purifier model.  The Core 600S feature-wise is very similar to the 400S, with key differences being the AUTO_STATUS payload type and a few payload indices.