### PR TITLE
Fix Core 300S status parsing (fanSpeedIndex, displayIndex) + minor logging cleanup

### DIFF
--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -105,7 +105,7 @@ void LevoitFan::control(const fan::FanCall &call) {
 
   if (call.get_speed().has_value()) {
     uint8_t targetSpeed = *call.get_speed();
-    ESP_LOGV(TAG, "Setting fan speed = %lu", targetSpeed);
+    ESP_LOGV(TAG, "Setting fan speed = %d", targetSpeed);
 
     switch (targetSpeed) {
       case 0:

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -46,7 +46,7 @@ void LevoitFan::setup() {
       }
       else
       {
-        ESP_LOGW(TAG, "Fan preset mode not set: %u", currentBits);
+        ESP_LOGW(TAG, "Fan preset mode not set: %lu", currentBits);
       }
 
       this->publish_state();
@@ -61,7 +61,7 @@ void LevoitFan::setup() {
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 4, 0)
       this->set_supported_preset_modes({"Manual", "Sleep", "Auto"});
 #else
-      this->traits_.set_supported_preset_modes({"Manual", "Sleep", "Auto"});
+      this->set_supported_preset_modes({"Manual", "Sleep", "Auto"});
 #endif
       break;
     case LevoitDeviceModel::CORE_300S:
@@ -69,7 +69,7 @@ void LevoitFan::setup() {
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 4, 0)
       this->set_supported_preset_modes({"Manual", "Sleep", "Auto"});
 #else
-      this->traits_.set_supported_preset_modes({"Manual", "Sleep", "Auto"});
+      this->set_supported_preset_modes({"Manual", "Sleep", "Auto"});
 #endif
       break;
     case LevoitDeviceModel::CORE_200S:
@@ -78,7 +78,7 @@ void LevoitFan::setup() {
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 4, 0)
       this->set_supported_preset_modes({"Manual", "Sleep"});
 #else
-      this->traits_.set_supported_preset_modes({"Manual", "Sleep"});
+      this->set_supported_preset_modes({"Manual", "Sleep"});
 #endif
       break;
   }
@@ -105,7 +105,7 @@ void LevoitFan::control(const fan::FanCall &call) {
 
   if (call.get_speed().has_value()) {
     uint8_t targetSpeed = *call.get_speed();
-    ESP_LOGV(TAG, "Setting fan speed = %u", targetSpeed);
+    ESP_LOGV(TAG, "Setting fan speed = %lu", targetSpeed);
 
     switch (targetSpeed) {
       case 0:

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -562,7 +562,11 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
             listener.func(currentBits);
           }
         }
-        ESP_LOGV(TAG, "Current State: %u, Requested On: %u, Request Off: %u", current_state_, req_on_state_, req_off_state_);
+        ESP_LOGV(TAG,
+         "Current State: %lu, Requested On: %lu, Request Off: %lu",
+         (unsigned long) current_state_,
+         (unsigned long) req_on_state_,
+         (unsigned long) req_off_state_);
       }
       xSemaphoreGive(stateChangeMutex_);
       xTaskNotifyGive(maintTaskHandle_);
@@ -605,8 +609,11 @@ void Levoit::set_request_state(uint32_t onMask, uint32_t offMask, bool acquireMu
     req_on_state_ &= ~offMask;
   }
 
-  ESP_LOGV(TAG, "set_request_state - Current State: %u, Requested On: %u, Request Off: %u", current_state_,
-           req_on_state_, req_off_state_);
+  ESP_LOGV(TAG,
+         "Current State: %lu, Requested On: %lu, Request Off: %lu",
+         (unsigned long) current_state_,
+         (unsigned long) req_on_state_,
+         (unsigned long) req_off_state_);
 
   if (gotMutex)
     xSemaphoreGive(stateChangeMutex_);

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -88,7 +88,7 @@ void Levoit::maint_task_() {
       
 
       if (previousState != current_state_) {
-        ESP_LOGV(TAG, "State Changed from %u to %u", previousState, current_state_);
+        ESP_LOGV(TAG, "State Changed from %lu to %lu", previousState, current_state_);
 
         uint32_t wifiLights = 
           static_cast<uint32_t>(LevoitState::WIFI_LIGHT_SOLID) |
@@ -346,9 +346,9 @@ void Levoit::process_rx_queue_task_() {
 
 void Levoit::dump_config() { 
     ESP_LOGCONFIG(TAG, "Levoit!"); 
-    ESP_LOGCONFIG(TAG, "  Command Delay: %d ms", this->command_delay_);
-    ESP_LOGCONFIG(TAG, "  Command Timeout: %d ms", this->command_timeout_);
-    ESP_LOGCONFIG(TAG, "  Status Poll Seconds: %d s", this->status_poll_seconds);
+    ESP_LOGCONFIG(TAG, "  Command Delay: %lu ms", this->command_delay_);
+    ESP_LOGCONFIG(TAG, "  Command Timeout: %lu ms", this->command_timeout_);
+    ESP_LOGCONFIG(TAG, "  Status Poll Seconds: %lu s", this->status_poll_seconds);
 }
 
 bool Levoit::validate_message_() {
@@ -417,7 +417,7 @@ bool Levoit::validate_message_() {
   if (data[1] != 0x12 || payloadLength - 3 != 1) {
     this->handle_payload_(payloadType, payload_data, payloadLength - 3);
   } else if (data[1] == 0x12) {
-    ESP_LOGV(TAG, "Received ACK (%06x)", (uint32_t) payloadType);
+    ESP_LOGV(TAG, "Received ACK (%06lx)", (unsigned long) payloadType);
   }
 
   // acknowledge packet if required
@@ -439,7 +439,7 @@ bool Levoit::validate_message_() {
 void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t len) {
   LevoitPayloadType payloadType = static_cast<LevoitPayloadType>(get_model_specific_payload_type(type));
 
-  ESP_LOGV(TAG, "Received command (%06x): %s", (uint32_t) payloadType, format_hex_pretty(payload, len).c_str());
+  ESP_LOGV(TAG, "Received command (%06lx): %s", (uint32_t) payloadType, format_hex_pretty(payload, len).c_str());
   
   if (payloadType == static_cast<LevoitPayloadType>(get_model_specific_payload_type(LevoitPayloadType::STATUS_RESPONSE)) 
         || payloadType == static_cast<LevoitPayloadType>(get_model_specific_payload_type(LevoitPayloadType::AUTO_STATUS))) {
@@ -467,6 +467,14 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
           fanSpeedIndex = 6;
           displayLockIndex = 11;
           break;
+		case LevoitDeviceModel::CORE_300S:
+		  fanSpeedIndex = 7;
+		  displayIndex = 9;
+		  break;
+
+		case LevoitDeviceModel::NONE:
+		  ESP_LOGW(TAG, "Device model NONE encountered");
+		  break;
       }
       bool display = payload[displayIndex] != 0x00;
       bool displayLock = payload[displayLockIndex] != 0x00;
@@ -537,7 +545,7 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
       set_bit_(current_state_, airQualityChange, LevoitState::AIR_QUALITY_CHANGE);
 
       if (previousState != current_state_) {
-        ESP_LOGV(TAG, "State Changed from %u to %u", previousState, current_state_);
+        ESP_LOGV(TAG, "State Changed from %lu to %lu", previousState, current_state_);
 
         uint32_t removeBits = current_state_ & req_on_state_;
         if (removeBits)
@@ -678,13 +686,13 @@ void Levoit::process_raw_command_(LevoitCommand command) {
                                   ? "ACK"
                                   : ((command.packetType == LevoitPacketType::SEND_MESSAGE) ? "CMD" : "UNKNOWN");
   this->write_array(rawPacket);
-  ESP_LOGV(TAG, "Sending %s (%06x): %s", packetTypeStr, (uint32_t) command.payloadType,
+  ESP_LOGV(TAG, "Sending %s (%06lx): %s", packetTypeStr, (uint32_t) command.payloadType,
            format_hex_pretty(rawPacket.data(), rawPacket.size()).c_str());
 
   // await ACK, not really needed but helps with pacing commands
   // command will retry if state is not achieved
   if (command.packetType != LevoitPacketType::ACK_MESSAGE && ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(command_timeout_)) == 0) {
-    ESP_LOGW(TAG, "Timeout waiting for ACK for command %s (%06x): %s", packetTypeStr, (uint32_t) command.payloadType,
+    ESP_LOGW(TAG, "Timeout waiting for ACK for command %s (%06lx): %s", packetTypeStr, (unsigned long) command.payloadType,
           format_hex_pretty(rawPacket.data(), rawPacket.size()).c_str());
   }
 }

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -468,8 +468,8 @@ void Levoit::handle_payload_(LevoitPayloadType type, uint8_t *payload, size_t le
           displayLockIndex = 11;
           break;
 		case LevoitDeviceModel::CORE_300S:
-		  fanSpeedIndex = 7;
-		  displayIndex = 9;
+		  fanSpeedIndex = 6;
+		  displayIndex = 7;
 		  break;
 
 		case LevoitDeviceModel::NONE:


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2>🛠 Fix Core 300S status parsing (fanSpeedIndex, displayIndex)</h2><p><span style="white-space: pre-wrap;">This PR fixes incorrect payload index mapping for the <strong style="white-space: pre-wrap;">Levoit Core 300S</strong>, which caused:</span></p><ul role="list"><li><p><span style="white-space: pre-wrap;">fan speed not being parsed</span></p></li><li><p><span style="white-space: pre-wrap;">display state not being parsed</span></p></li><li><p><span style="white-space: pre-wrap;">incorrect state bitmask updates</span></p></li><li><p><span style="white-space: pre-wrap;">Home Assistant showing wrong or missing fan state</span></p></li><li><p><span style="white-space: pre-wrap;">auto mode transitions not being recognized correctly</span></p></li></ul><h3>✔ What was wrong</h3><p><span style="white-space: pre-wrap;">The Core 300S uses different payload indices than the Core 400S/600S.
Previously, the component used:</span></p><div><div><div><span>Code</span><button type="button" title="Codeausschnitt reduzieren" aria-expanded="true"><svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M8.46967 4.21967C8.17678 4.51256 8.17678 4.98744 8.46967 5.28033L15.1893 12L8.46967 18.7197C8.17678 19.0126 8.17678 19.4874 8.46967 19.7803C8.76256 20.0732 9.23744 20.0732 9.53033 19.7803L16.7803 12.5303C17.0732 12.2374 17.0732 11.7626 16.7803 11.4697L9.53033 4.21967C9.23744 3.92678 8.76256 3.92678 8.46967 4.21967Z"></path></svg></button></div><div></div></div><div class="rounded-b-xl bg-background-static-850 px-4 pb-1.5 dark:bg-background-static-900"><div style="white-space: pre;"><pre style="white-space: pre;"><code style="white-space: pre;">fanSpeedIndex = 7
displayIndex = 9
</code></pre></div></div></div><p><span style="white-space: pre-wrap;">But the actual Core 300S status frame layout is:</span></p><div><div><div tabindex="0" role="group" aria-label="Scrollbare Tabelle">
Field | Correct Index
-- | --
4
5
6
7
11
12
13

</div><div></div></div><div><div><button aria-label="Tabelle kopieren" type="button" data-testid="copy-table-button" data-spatial-navigation-autofocus="false" data-tooltip-state="closed"><div><svg viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M8 2C6.89543 2 6 2.89543 6 4V14C6 15.1046 6.89543 16 8 16H14C15.1046 16 16 15.1046 16 14V4C16 2.89543 15.1046 2 14 2H8ZM7 4C7 3.44772 7.44772 3 8 3H14C14.5523 3 15 3.44772 15 4V14C15 14.5523 14.5523 15 14 15H8C7.44772 15 7 14.5523 7 14V4ZM4 6.00001C4 5.25973 4.4022 4.61339 5 4.26758V14.5C5 15.8807 6.11929 17 7.5 17H13.7324C13.3866 17.5978 12.7403 18 12 18H7.5C5.567 18 4 16.433 4 14.5V6.00001Z"></path></svg></div></button><div></div></div><div><button aria-label="Tabelle herunterladen" type="button" data-testid="download-table-button" data-spatial-navigation-autofocus="false" data-tooltip-state="closed"><div><svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M18.2498 20.5009C18.664 20.5008 19 20.8365 19 21.2507C19 21.6649 18.6644 22.0008 18.2502 22.0009L5.25022 22.0047C4.836 22.0048 4.5 21.6691 4.5 21.2549C4.5 20.8407 4.83557 20.5048 5.24978 20.5047L18.2498 20.5009ZM11.6482 2.01271L11.75 2.00586C12.1297 2.00586 12.4435 2.28801 12.4932 2.65409L12.5 2.75586L12.499 16.4409L16.2208 12.7205C16.4871 12.4543 16.9038 12.4301 17.1974 12.648L17.2815 12.7206C17.5477 12.9869 17.5719 13.4036 17.354 13.6972L17.2814 13.7813L12.2837 18.7779C12.0176 19.044 11.6012 19.0683 11.3076 18.8507L11.2235 18.7782L6.22003 13.7816C5.92694 13.4889 5.92661 13.014 6.21931 12.7209C6.48539 12.4545 6.90204 12.43 7.1958 12.6477L7.27997 12.7202L10.999 16.4339L11 2.75586C11 2.37616 11.2822 2.06237 11.6482 2.01271L11.75 2.00586L11.6482 2.01271Z" fill="currentColor"></path></svg></div></button><div></div></div></div></div><p><span style="white-space: pre-wrap;">This caused fan speed to be interpreted as display brightness (0x64), and display brightness to be interpreted as AQI.</span></p><h3>✔ Fix implemented</h3><p><span style="white-space: pre-wrap;">Updated the model‑specific index mapping:</span></p><div><div><div><span>cpp</span><button type="button" title="Codeausschnitt reduzieren" aria-expanded="true"><svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M8.46967 4.21967C8.17678 4.51256 8.17678 4.98744 8.46967 5.28033L15.1893 12L8.46967 18.7197C8.17678 19.0126 8.17678 19.4874 8.46967 19.7803C8.76256 20.0732 9.23744 20.0732 9.53033 19.7803L16.7803 12.5303C17.0732 12.2374 17.0732 11.7626 16.7803 11.4697L9.53033 4.21967C9.23744 3.92678 8.76256 3.92678 8.46967 4.21967Z"></path></svg></button></div><div></div></div><div class="rounded-b-xl bg-background-static-850 px-4 pb-1.5 dark:bg-background-static-900"><div style="white-space: pre;"><pre style="white-space: pre;"><code style="white-space: pre;"><span style="white-space: pre;"><span style="white-space: pre;">case</span></span><span style="white-space: pre;"> </span><span style="white-space: pre;">LevoitDeviceModel::CORE_300S:
    </span><span style="white-space: pre;">fanSpeedIndex </span><span style="white-space: pre;">= </span><span style="white-space: pre;"><span style="white-space: pre;">6</span></span><span style="white-space: pre;">;
    </span><span style="white-space: pre;">displayIndex </span><span style="white-space: pre;">= </span><span style="white-space: pre;"><span style="white-space: pre;">7</span></span><span style="white-space: pre;">;
    </span><span style="white-space: pre;"><span style="white-space: pre;">// displayLockIndex remains 14</span></span><span style="white-space: pre;">
    </span><span style="white-space: pre;"><span style="white-space: pre;">break</span></span><span style="white-space: pre;">;
</span></code></pre></div></div></div><h3>✔ Result</h3><ul role="list"><li><p><span style="white-space: pre-wrap;">Fan speed is parsed correctly (1–3 in manual mode, 0 in auto mode)</span></p></li><li><p><span style="white-space: pre-wrap;">Display state is parsed correctly</span></p></li><li><p><span style="white-space: pre-wrap;">PM2.5 and AQI parsing remain correct</span></p></li><li><p><span style="white-space: pre-wrap;">Auto mode transitions work as expected</span></p></li><li><p><span style="white-space: pre-wrap;">Home Assistant receives correct fan_state_response updates</span></p></li></ul><h3>✔ Additional cleanup</h3><p><span style="white-space: pre-wrap;">Fixed a minor logging warning in <code style="white-space: pre-wrap;">levoit_fan.cpp</code>:</span></p><div><div><div><span>cpp</span><button type="button" title="Codeausschnitt reduzieren" aria-expanded="true"><svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M8.46967 4.21967C8.17678 4.51256 8.17678 4.98744 8.46967 5.28033L15.1893 12L8.46967 18.7197C8.17678 19.0126 8.17678 19.4874 8.46967 19.7803C8.76256 20.0732 9.23744 20.0732 9.53033 19.7803L16.7803 12.5303C17.0732 12.2374 17.0732 11.7626 16.7803 11.4697L9.53033 4.21967C9.23744 3.92678 8.76256 3.92678 8.46967 4.21967Z"></path></svg></button></div><div></div></div><div class="rounded-b-xl bg-background-static-850 px-4 pb-1.5 dark:bg-background-static-900"><div style="white-space: pre;"><pre style="white-space: pre;"><code style="white-space: pre;"><span style="white-space: pre;"><span style="white-space: pre;">ESP_LOGV</span></span><span style="white-space: pre;">(TAG, </span><span style="white-space: pre;"><span style="white-space: pre;">"Setting fan speed = %d"</span></span><span style="white-space: pre;">, </span><span style="white-space: pre;">targetSpeed);
</span></code></pre></div></div></div><p><span style="white-space: pre-wrap;">(Previously used <code style="white-space: pre-wrap;">%lu</code> with an <code style="white-space: pre-wrap;">int</code>.)</span></p><div></div><h2>📡 Tested devices</h2><ul role="list"><li><p><span style="white-space: pre-wrap;">Levoit Core 300S (real hardware)</span></p></li><li><p><span style="white-space: pre-wrap;">Manual mode (1/2/3)</span></p></li><li><p><span style="white-space: pre-wrap;">Auto mode</span></p></li><li><p><span style="white-space: pre-wrap;">Display on/off</span></p></li><li><p><span style="white-space: pre-wrap;">PM2.5 sensor updates</span></p></li><li><p><span style="white-space: pre-wrap;">HA fan entity + select entities</span></p></li></ul><p><span style="white-space: pre-wrap;">All functions verified working.</span></p><div></div><h2>🙌 Notes</h2><p><span style="white-space: pre-wrap;">This PR does not change behavior for Core 200S / 400S / 600S.
Only the Core 300S model mapping is corrected.</span></p><!--EndFragment-->
</body>
</html>